### PR TITLE
Refactor/#19 chatbot refactoring

### DIFF
--- a/src/main/java/academic_festival/gyeonggi_go/chatbot/Service/ChatbotService.java
+++ b/src/main/java/academic_festival/gyeonggi_go/chatbot/Service/ChatbotService.java
@@ -3,6 +3,7 @@ package academic_festival.gyeonggi_go.chatbot.Service;
 import academic_festival.gyeonggi_go.chatbot.Dto.Response.ChatbotDataDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,16 +16,18 @@ import java.util.Map;
 public class ChatbotService {
     private final WebClient webClient;
     private final String apiKey;
-    private final TtsService ttsService;
+    //rivate final TtsService ttsService;
+    private final ObjectProvider<TtsService> ttsServiceProvider;
     private static final Logger logger = LoggerFactory.getLogger(ChatbotService.class);
 
     public ChatbotService(WebClient.Builder webClientBuilder,
                           @Value("${gemini.api.url}") String apiUrl,
                           @Value("${gemini.api.key}") String apiKey,
-                          TtsService ttsService) {
+                          ObjectProvider<TtsService> ttsServiceProvider) {
         this.webClient = webClientBuilder.baseUrl(apiUrl).build();
         this.apiKey = apiKey;
-        this.ttsService = ttsService;
+        //this.ttsService = ttsService;
+        this.ttsServiceProvider = ttsServiceProvider;
     }
 
     //Gemini API 호출 메서드
@@ -69,12 +72,13 @@ public class ChatbotService {
         }
 
         // TTS 변환 Mono
-        Mono<byte[]> ttsMono = ttsService.synthesizeText(geminiDto.getAnswer())
+        Mono<byte[]> ttsMono = synthesizeIfAvailable(geminiDto.getAnswer())
                 .onErrorResume(e -> {
                     // TTS 실패 시 에러 로그만 남기고 빈 Mono 반환 (오디오 없이 응답)
                     logger.warn("TTS synthesis failed: {}", e.getMessage());
                     return Mono.empty(); // 오디오 데이터는 null이 됨
                 });
+
 
         // 기존 Gemini DTO와 TTS 결과를 병합
         return Mono.zip(Mono.just(geminiDto), ttsMono.map(this::encodeBase64).defaultIfEmpty(""))
@@ -86,6 +90,17 @@ public class ChatbotService {
                     return new ChatbotDataDto(dto.getAnswer(), dto.getSuggestedQuestions(), audioBase64);
                 });
     }
+
+    // [수정] TtsService가 사용 가능할 때만 호출하는 헬퍼 메서드 추가
+    private Mono<byte[]> synthesizeIfAvailable(String text) {
+        TtsService service = ttsServiceProvider.getIfAvailable();
+        if (service == null) {
+            logger.warn("TTS 서비스가 구성되지 않아 오디오를 생성하지 않습니다.");
+            return Mono.empty();
+        }
+        return service.synthesizeText(text);
+    }
+
 
     // Base64 인코더 헬퍼 메서드
     private String encodeBase64(byte[] audioBytes) {
@@ -121,7 +136,7 @@ public class ChatbotService {
                     // 3. TTS Mono 생성 (enableTts == true 일 때만 인사말을 변환)
                     Mono<String> ttsMono;
                     if (enableTts) {
-                        ttsMono = ttsService.synthesizeText(greeting) //인사말만 TTS로 변환!
+                        ttsMono = synthesizeIfAvailable(greeting) //인사말만 TTS로 변환!
                                 .map(this::encodeBase64) //byte를 Base64 로변경
                                 .onErrorResume(e -> {
                                     logger.warn("TTS synthesis failed for greeting: {}", e.getMessage());
@@ -131,6 +146,7 @@ public class ChatbotService {
                     } else {
                         ttsMono = Mono.just("");
                     }
+
 
                     // 4. 제미나이 결과와 TTS 결과를 합쳐서 최종 DTO 생성
                     return Mono.zip(geminiMono, ttsMono)

--- a/src/main/java/academic_festival/gyeonggi_go/chatbot/Service/ChatbotService.java
+++ b/src/main/java/academic_festival/gyeonggi_go/chatbot/Service/ChatbotService.java
@@ -91,7 +91,7 @@ public class ChatbotService {
                 });
     }
 
-    // [수정] TtsService가 사용 가능할 때만 호출하는 헬퍼 메서드 추가
+    // TtsService가 사용 가능할 때만 호출하는 헬퍼 메서드 추가
     private Mono<byte[]> synthesizeIfAvailable(String text) {
         TtsService service = ttsServiceProvider.getIfAvailable();
         if (service == null) {

--- a/src/main/java/academic_festival/gyeonggi_go/config/TtsConfig.java
+++ b/src/main/java/academic_festival/gyeonggi_go/config/TtsConfig.java
@@ -1,6 +1,7 @@
 package academic_festival.gyeonggi_go.config;
 
 import com.google.cloud.texttospeech.v1.TextToSpeechClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,6 +10,7 @@ import java.io.IOException;
 @Configuration
 public class TtsConfig {
     @Bean
+    @ConditionalOnProperty(value = "tts.enabled", havingValue = "true", matchIfMissing = false)
     public TextToSpeechClient textToSpeechClient() throws IOException {
         return TextToSpeechClient.create();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,5 @@ spring.jpa.properties.hibernate.format_sql=true
 
 gyeonggi.api.keys=${GYEONGGI_API_KEYS}
 gyeonggi.api.urls=${GYEONGGI_API_URLS}
+
+tts.enabled=true


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #19 

## 📄 작업 내용
- 1. GCP 자격증명이 없으면 애플리케이션이 부팅되지 않는점 수정 
: 현재 TextToSpeechClient.create()가 Bean 생성 시점에 실행되는데, ADC가 없는 로컬/CI 환경에서는 IOException: Application Default Credentials are not available가 터지면서 스프링 컨텍스트가 바로 죽음. enableTts=false 요청만으로는 회피가 불가능해 배포 자체가 막힘 => 프로퍼티로 Bean 생성을 조건부 처리하거나 최초 요청 시점까지 생성을 미루는 방식이 필요. 아래처럼 프로퍼티 기반으로 Bean을 만들고, 미구성 시 Bean이 아예 등록되지 않도록 하는 방향으로 수정

- 2. TTS Bean 실패 시 전체 서비스가 중단됩니다
: 지금은 TtsService를 필수 의존성으로 주입하고 있는데, TextToSpeechClient 생성이 자격증명을 찾지 못하면 예외가 발생해 애플리케이션이 부팅되지 않음. ObjectProvider<TtsService>와 같은 지연 의존성으로 바꾸고, 실제 호출 전에 Bean 존재 여부를 확인해 TTS만 우회하도록함.